### PR TITLE
Like feature fix

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -8,8 +8,6 @@ class LikesController < ApplicationController
     authorize @like
     if @like.save
       redirect_to request.referrer
-    else
-      redirect_to request.referrer
     end
   end
 
@@ -17,8 +15,6 @@ class LikesController < ApplicationController
     @like = @post.likes.find_by(user: current_user.id)
     authorize @like
     if @like.destroy
-      redirect_to request.referrer
-    else
       redirect_to request.referrer
     end
   end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -7,9 +7,9 @@ class LikesController < ApplicationController
     @like.post = @post
     authorize @like
     if @like.save
-      redirect_to feed_users_path( anchor: "post-#{@post.id}" )
+      redirect_to request.referrer
     else
-      render :feed_users
+      redirect_to request.referrer
     end
   end
 
@@ -17,9 +17,9 @@ class LikesController < ApplicationController
     @like = @post.likes.find_by(user: current_user.id)
     authorize @like
     if @like.destroy
-      redirect_to feed_users_path( anchor: "post-#{@post.id}" )
+      redirect_to request.referrer
     else
-      render :feed_users
+      redirect_to request.referrer
     end
   end
   

--- a/app/views/shared/_post_display.html.erb
+++ b/app/views/shared/_post_display.html.erb
@@ -28,7 +28,7 @@
       </div>
       <div class="post-action">
         <ul class="list-inline">
-          <li class="list-inline-item" data-controller="like">
+          <li class="list-inline-item">
             <% if post.has_like?(current_user) %>
               <%= link_to like_path(post), method: "DELETE", remote: true do %>
                 <%= cl_image_tag 'liked_icon_iyj0h1.png', class: 'post-icon liked', remote: true %>
@@ -38,7 +38,7 @@
               <%= cl_image_tag 'like-icon.png', data_like_target: "like", class: 'post-icon', remote: true %>
               <% end %>
             <% end %>
-            <spa data-action="click->like#refresh">
+            <span>
               <%= post.likes.count %>
             </span>
           </li>


### PR DESCRIPTION
It does not redirect to feed anymore. Stay on the same page that sent the request but still no anchor on the post. When like action happens it goes to the top of the page