### PR TITLE
added a pointer cursor when hover chat 'links'

### DIFF
--- a/app/assets/stylesheets/chat/_chat_memberships.scss
+++ b/app/assets/stylesheets/chat/_chat_memberships.scss
@@ -17,3 +17,7 @@
   align-items: center;
   margin-left: 0.5rem;
 }
+
+.chat-action {
+  cursor: pointer;
+}


### PR DESCRIPTION
When hovering a specific chat on the messages container the cursor will change for a pointer instead of stay as a text cursor